### PR TITLE
pnote_user_fix

### DIFF
--- a/library/pnotes.inc
+++ b/library/pnotes.inc
@@ -73,7 +73,7 @@ function getPnotesByUser($activity="1",$show_all="no",$user='',$count=false,$sor
           patient_data.fname as patient_data_fname, patient_data.lname as patient_data_lname
           FROM ((pnotes LEFT JOIN users ON pnotes.user = users.username)
           LEFT JOIN patient_data ON pnotes.pid = patient_data.pid) WHERE $activity_query
-          pnotes.deleted != '1' AND pnotes.assigned_to LIKE ?";
+          pnotes.deleted != '1' AND pnotes.assigned_to = ?";
   if (!empty($sortby) || !empty($sortorder)  || !empty($begin) || !empty($listnumber)) {
     $sql .= " order by ".escape_sql_column_name($sortby,array('users','patient_data','pnotes'),TRUE).
             " ".escape_sort_order($sortorder).
@@ -129,7 +129,7 @@ $sqlParameterArray = array();
     }
   }
   if ($username) {
-    $sql .= " AND assigned_to LIKE ?";
+    $sql .= " AND assigned_to = ?";
     array_push($sqlParameterArray, $username);
   }
   if ($status)
@@ -180,7 +180,7 @@ $sqlParameterArray = array();
     }
   }
   if ($username) {
-    $sql .= " AND assigned_to LIKE ?";
+    $sql .= " AND assigned_to = ?";
     array_push($sqlParameterArray, $username);
   }
   if ($status)


### PR DESCRIPTION
LIKE comparisons result in duplicate messages sent to and from different
providers.  Other weaknesses may be apparent with LIKE `pid`.  Further
investigation needed...or just a much more modern message tool!