### PR TITLE
Change Facility to Place of Service

### DIFF
--- a/interface/forms/patient_encounter/common.php
+++ b/interface/forms/patient_encounter/common.php
@@ -202,7 +202,7 @@ function cancelClicked() {
     </tr>
 
     <tr>
-     <td class='bold' nowrap><?php echo xlt('Facility:'); ?></td>
+     <td class='bold' nowrap><?php echo xlt('Place of Service:'); ?></td>
      <td class='text'>
       <select name='facility_id' onChange="bill_loc()">
 <?php


### PR DESCRIPTION
Billing Facility and Facility are really poorly understood by users.
This naming convention is responsible for a lot of confusion and billing
failures. 
The only quandary is what to do to ensure that the Place of Service is the Location Code source.  I have seen this one tiny change help several businesses get things together.