### PR TITLE
claims table autoinc triple key innodb failure

### DIFF
--- a/library/billing.inc
+++ b/library/billing.inc
@@ -166,11 +166,15 @@ function updateClaim($newversion, $patient_id, $encounter_id, $payer_id=-1, $pay
       "target = '$target', " .
       "x12_partner_id = '$partner_id'";
     ****/
+    $inc_version = sqlQuery("SELECT MAX(version)+1 FROM claims ".
+      "WHERE patient_id = '$patient_id' ".
+      "AND encounter_id = '$encounter_id';");
     if($crossover<>1)
     {
     $sql = "INSERT INTO claims SET " .
       "patient_id = '$patient_id', " .
       "encounter_id = '$encounter_id', " .
+      "version = '$inc_version', ".
       "bill_time = NOW() $claimset";
       }
      else
@@ -179,6 +183,7 @@ function updateClaim($newversion, $patient_id, $encounter_id, $payer_id=-1, $pay
      $sql = "INSERT INTO claims SET " .
       "patient_id = '$patient_id', " .
       "encounter_id = '$encounter_id', " .
+      "version = '$inc_version', ".
       "bill_time = NOW(), status=$status";
      
      }

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -272,7 +272,7 @@ DROP TABLE IF EXISTS `claims`;
 CREATE TABLE `claims` (
   `patient_id` int(11) NOT NULL,
   `encounter_id` int(11) NOT NULL,
-  `version` int(10) unsigned NOT NULL auto_increment,
+  `version` tinyint(2) unsigned NOT NULL,
   `payer_id` int(11) NOT NULL default '0',
   `status` tinyint(2) NOT NULL default '0',
   `payer_type` tinyint(4) NOT NULL default '0',
@@ -283,7 +283,7 @@ CREATE TABLE `claims` (
   `target` varchar(30) default NULL,
   `x12_partner_id` int(11) NOT NULL default '0',
   PRIMARY KEY  (`patient_id`,`encounter_id`,`version`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 ;
+) ENGINE=InnoDB;
 
 
 --


### PR DESCRIPTION
#167 claims table uses a triple primary key with encounter, pid and an
autoincrement of 'version' integer.
Updating seems to only happen via billing.inc and only when the
$newversion flag is set.  Testing to follow.