### PR TITLE
Add Legal Business Entity Name to Facilities

### DIFF
--- a/interface/usergroup/facilities.php
+++ b/interface/usergroup/facilities.php
@@ -10,6 +10,7 @@ $alertmsg = '';
 if (isset($_POST["mode"]) && $_POST["mode"] == "facility" && $_POST["newmode"] != "admin_facility") {
   $insert_id=sqlInsert("INSERT INTO facility SET " .
   "name = '"         . trim(formData('facility'    )) . "', " .
+  "alias = '"         . trim(formData('alias'    )) . "', " .
   "phone = '"        . trim(formData('phone'       )) . "', " .
   "fax = '"          . trim(formData('fax'         )) . "', " .
   "street = '"       . trim(formData('street'      )) . "', " .
@@ -37,6 +38,7 @@ if ($_POST["mode"] == "facility" && $_POST["newmode"] == "admin_facility")
 {
 	sqlStatement("update facility set
 		name='" . trim(formData('facility')) . "',
+		alias = '" . trim(formData('alias')) . "',
 		phone='" . trim(formData('phone')) . "',
 		fax='" . trim(formData('fax')) . "',
 		street='" . trim(formData('street')) . "',

--- a/interface/usergroup/facility_admin.php
+++ b/interface/usergroup/facility_admin.php
@@ -139,20 +139,22 @@ function displayAlert()
          <tr>
           <td width='150px'><span class='text'><?php xl('Name','e'); ?>: </span></td>
           <td width='220px'><input type='entry' name='facility' size='20' value='<?php echo htmlspecialchars($facility['name'], ENT_QUOTES) ?>'><font class="mandatory">&nbsp;*</font></td>
+          <td width='150px'><span class='text'><?php xl('Legal Entity','e'); ?>: </span></td>
+          <td width='220px'><input type='entry' name='alias' size='20' value='<?php echo htmlspecialchars($facility['alias'], ENT_QUOTES) ?>'><font class="mandatory">&nbsp;*</font></td>
+          </tr>
+         <tr>
+         <td><span class=text><?php xl('Address','e'); ?>: </span></td><td><input type=entry size=20 name=street value="<?php echo htmlspecialchars($facility["street"], ENT_QUOTES) ?>"></td>
           <td width='200px'><span class='text'><?php xl('Phone','e'); ?> <?php xl('as','e'); ?> (000) 000-0000:</span></td>
           <td width='220px'><input type='entry' name='phone' size='20' value='<?php echo htmlspecialchars($facility['phone'], ENT_QUOTES) ?>'></td>
          </tr>
          <tr>
-          <td><span class=text><?php xl('Address','e'); ?>: </span></td><td><input type=entry size=20 name=street value="<?php echo htmlspecialchars($facility["street"], ENT_QUOTES) ?>"></td>
+             <td><span class=text><?php xl('City','e'); ?>: </span></td>
+            <td><input type=entry size=20 name=city value="<?php echo htmlspecialchars($facility{"city"}, ENT_QUOTES) ?>"></td>
           <td><span class='text'><?php xl('Fax','e'); ?> <?php xl('as','e'); ?> (000) 000-0000:</span></td>
           <td><input type='entry' name='fax' size='20' value='<?php echo htmlspecialchars($facility['fax'], ENT_QUOTES) ?>'></td>
          </tr>
         <tr>
-
-            <td><span class=text><?php xl('City','e'); ?>: </span></td>
-            <td><input type=entry size=20 name=city value="<?php echo htmlspecialchars($facility{"city"}, ENT_QUOTES) ?>"></td>
-            <td><span class=text><?php xl('Zip Code','e'); ?>: </span></td><td><input type=entry size=20 name=postal_code value="<?php echo htmlspecialchars($facility{"postal_code"}, ENT_QUOTES) ?>"></td>
-        </tr>
+<td><span class=text><?php xl('State','e'); ?>: </span></td><td><input type=entry size=20 name=state value="<?php echo htmlspecialchars($facility{"state"}, ENT_QUOTES) ?>"></td>
 	<?php 
 		$ssn='';
 		$ein='';
@@ -162,16 +164,17 @@ function displayAlert()
 		else{
 		$ein='selected';
 		}
-	?>
-        <tr>
-            <td><span class=text><?php xl('State','e'); ?>: </span></td><td><input type=entry size=20 name=state value="<?php echo htmlspecialchars($facility{"state"}, ENT_QUOTES) ?>"></td>
+	?>     
             <td><span class=text><?php xl('Tax ID','e'); ?>: </span></td><td><select name=tax_id_type><option value="EI" <?php echo $ein;?>><?php xl('EIN','e'); ?></option><option value="SY" <?php echo $ssn;?>><?php xl('SSN','e'); ?></option></select><input type=entry size=11 name=federal_ein value="<?php echo htmlspecialchars($facility{"federal_ein"}, ENT_QUOTES) ?>"></td>
         </tr>
         <tr>
-            <td><span class=text><?php xl('Country','e'); ?>: </span></td><td><input type=entry size=20 name=country_code value="<?php echo htmlspecialchars($facility{"country_code"}, ENT_QUOTES) ?>"></td>
-            <td width="21"><span class=text><?php ($GLOBALS['simplified_demographics'] ? xl('Facility Code','e') : xl('Facility NPI','e')); ?>:
+        <td><span class=text><?php xl('Zip Code','e'); ?>: </span></td><td><input type=entry size=20 name=postal_code value="<?php echo htmlspecialchars($facility{"postal_code"}, ENT_QUOTES) ?>"></td>
+        <td width="21"><span class=text><?php ($GLOBALS['simplified_demographics'] ? xl('Facility Code','e') : xl('Facility NPI','e')); ?>:
           </span></td><td><input type=entry size=20 name=facility_npi value="<?php echo htmlspecialchars($facility{"facility_npi"}, ENT_QUOTES) ?>"></td>
-        </tr>
+          </tr>
+		 <tr>
+            <td><span class=text><?php xl('Country','e'); ?>: </span></td><td><input type=entry size=20 name=country_code value="<?php echo htmlspecialchars($facility{"country_code"}, ENT_QUOTES) ?>"></td>
+            </tr>
 		 <tr>
             <td><span class=text><?php xl('Website','e'); ?>: </span></td><td><input type=entry size=20 name=website value="<?php echo htmlspecialchars($facility{"website"}, ENT_QUOTES) ?>"></td>
             <td><span class=text><?php xl('Email','e'); ?>: </span></td><td><input type=entry size=20 name=email value="<?php echo htmlspecialchars($facility{"email"}, ENT_QUOTES) ?>"></td>

--- a/library/Claim.class.php
+++ b/library/Claim.class.php
@@ -203,7 +203,7 @@ class Claim {
     // try the first (and hopefully only) facility marked as a billing location.
     if (empty($this->encounter['billing_facility'])) {
       $sql = "SELECT * FROM facility " .
-        "ORDER BY billing_location DESC, id ASC LIMIT 1";
+        "ORDER BY billing_location, primary_business_entity DESC, id ASC LIMIT 1";
     }
     else {
       $sql = "SELECT * FROM facility " .
@@ -582,7 +582,7 @@ class Claim {
   }
 
   function billingFacilityName() {
-    return x12clean(trim($this->billing_facility['name']));
+    return x12clean(trim($this->billing_facility['alias']));
   }
 
   function billingFacilityStreet() {

--- a/sql/0_0_1-to-1_0_0_upgrade.sql
+++ b/sql/0_0_1-to-1_0_0_upgrade.sql
@@ -539,6 +539,10 @@ ALTER TABLE users ADD COLUMN physician_type VARCHAR(50) DEFAULT NULL;
 ALTER TABLE facility ADD COLUMN facility_code VARCHAR(31) default NULL;
 #EndIf
 
+#IfMissingColumn facility alias
+ALTER TABLE facility ADD COLUMN alias VARCHAR(60) default NULL;
+#EndIf
+
 #IfMissingColumn documents audit_master_approval_status
 ALTER TABLE documents ADD COLUMN audit_master_approval_status TINYINT DEFAULT 1 NOT NULL COMMENT 'approval_status from audit_master table';
 #EndIf

--- a/sql/database.sql
+++ b/sql/database.sql
@@ -1159,6 +1159,7 @@ DROP TABLE IF EXISTS `facility`;
 CREATE TABLE `facility` (
   `id` int(11) NOT NULL auto_increment,
   `name` varchar(255) default NULL,
+  `alias varchar(60) default NULL,
   `phone` varchar(30) default NULL,
   `fax` varchar(30) default NULL,
   `street` varchar(255) default NULL,

--- a/sql/libreehr_upgrade.sql
+++ b/sql/libreehr_upgrade.sql
@@ -9,4 +9,4 @@ RENAME TABLE `openemr_session_info` TO `libreehr_session_info`;
 RENAME TABLE `openemr_module_vars` TO `libreehr_module_vars`;
 UPDATE `forms` SET `form_name` = 'Patient Encounter' WHERE `form_name` = 'New Patient Encounter';
 UPDATE `registry` SET `name` = 'Patient Encounter', `directory` = 'patient_encounter' WHERE `directory` = 'newpatient';
-
+ALTER TABLE facility ADD COLUMN alias VARCHAR(60) default NULL;


### PR DESCRIPTION
Uses the legal business entity name in EDI, letting the users call their
facilities other names that identify the location code, such as "Office,
Home, ALF, Hospital, etc...".
  This corrects a lot of trouble, and should be added to the CMS-1500 code as well.
  The decision to use alias instead of altering the behavior of name was due to extent of it's use, and there is a reasonable argument for that in any case.