### PR TITLE
Hooks for appt and patient save and patient tracker appt stautus change

### DIFF
--- a/interface/main/calendar/add_edit_event.php
+++ b/interface/main/calendar/add_edit_event.php
@@ -535,6 +535,12 @@ if ($_POST['form_action'] == "save") {
         $event_date = fixDate($_POST['event_start_date']);
     }
 
+                do_action( 'before_update_event',
+                    $data = [ 'id' => $eid, 'pid' => $_POST['form_pid'],
+                        'provider' => $_POST['form_provider'], 'date' => $event_date, 'starttime' => $starttime,
+                        'category' => $_POST['form_category'], 'status' => $_POST['form_apptstatus'], 'title' => $_POST['form_title'],
+                    ] );
+
                 // mod the SINGLE event or ALL EVENTS in a repeating series
                 // simple provider case
                 sqlStatement("UPDATE libreehr_postcalendar_events SET " .

--- a/library/patient.inc
+++ b/library/patient.inc
@@ -1024,6 +1024,8 @@ function updatePatientData($pid, $new, $create=false)
     return sqlInsert($sql);
   *******************************************************************/
 
+    do_action( 'update_patient_data_before_save', $new );
+
   // The above was broken, though seems intent to insert a new patient_data
   // row for each update.  A good idea, but nothing is doing that yet so
   // the code below does not yet attempt it.
@@ -1054,6 +1056,8 @@ function updatePatientData($pid, $new, $create=false)
     $sql .= " WHERE id = '$db_id'";
     sqlStatement($sql);
   }
+
+  do_action( 'update_patient_data_after_save', $new );
 
   return $db_id;
 }

--- a/library/patient_tracker.inc.php
+++ b/library/patient_tracker.inc.php
@@ -227,7 +227,7 @@ function manage_tracker_status($apptdate,$appttime,$eid,$pid,$user,$status='',$r
     $tracker_id = $tracker['id'];
     if (($status != $tracker['laststatus']) || ($room != $tracker['lastroom'])) {
       #Status or room has changed, so need to update tracker.
-      #Update lastseq in tracker.	  
+      #Update lastseq in tracker.
 	   sqlStatement("UPDATE `patient_tracker` SET  `lastseq` = ? WHERE `id` = ?",
                    array(($tracker['lastseq']+1),$tracker_id));
       #Add a tracker item.
@@ -235,12 +235,14 @@ function manage_tracker_status($apptdate,$appttime,$eid,$pid,$user,$status='',$r
                 "(`pt_tracker_id`, `start_datetime`, `user`, `status`, `room`, `seq`) " .
                 "VALUES (?,?,?,?,?,?)",
                 array($tracker_id,$datetime,$user,$status,$room,($tracker['lastseq']+1)));
+        do_action( 'tracker_status_changed', $args = [ 'tracker_id' => $tracker_id, 'current_status' => $status, 'last_status' => $tracker['laststatus'] ] );
     }
     if (!empty($enc_id)) {
       #enc_id (encounter number) is not blank, so update this in tracker.
       sqlStatement("UPDATE `patient_tracker` SET `encounter` = ? WHERE `id` = ?", array($enc_id,$tracker_id));
     }  
   }
+
   #Ensure the entry in calendar appt entry has been updated.
   $pc_appt =  sqlQuery("SELECT `pc_apptstatus`, `pc_room` FROM `libreehr_postcalendar_events` WHERE `pc_eid` = ?", array($eid));
   if ($status != $pc_appt['pc_apptstatus']) {


### PR DESCRIPTION
I added do_action() hooks so custom behavior can be added when: an appointment is saved, a patient is saved, the appointment status is changed on patient tracker.