### PR TITLE
Returned globals init hook that got removed

### DIFF
--- a/library/globals.inc.php
+++ b/library/globals.inc.php
@@ -2684,8 +2684,13 @@ $GLOBALS_METADATA = array(
     ),
 	
    ),
-   
+
 
    
 );
+
+if ( function_exists( 'do_action' ) ) {
+    do_action( GLOBALS_INIT, $GLOBALS_METADATA );
+}
+
 ?>


### PR DESCRIPTION
This is the hook that allows for globals to be dynamically added by a plugin. At some point it got removed, probably by a conflict-resolving merge.